### PR TITLE
Add CI for the suite's own checks; fix CITATION.cff author fields

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,24 @@
+name: verify
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Suite integrity check
+        run: python j-space/scripts/verify_suite.py
+      - name: Controller regression tests
+        run: python -m unittest discover -s tests -v

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,9 +7,6 @@ message: "If you use J-Space in your research, please cite the accompanying pape
 title: "J-Space Cognition Suite V3.6"
 authors:
   - family-names: "Tiger3807861189"
-    given-names: ""
-    orcid: ""
-    affiliation: ""
 date-released: "2026-08-17"
 version: "3.6"
 doi: "10.5281/zenodo.21971181"


### PR DESCRIPTION
Fixes #12

**Goal:** the two checks this repo already ships (`scripts/verify_suite.py`, `tests/`) run automatically on every push and PR, and `CITATION.cff` parses cleanly against CFF 1.2.0.

**Changes**

1. `.github/workflows/verify.yml` — one workflow, three OS families (the controller's encoding handling explicitly targets Windows as well as POSIX), zero new dependencies — standard library only, matching the suite's own constraint. `workflow_dispatch` included so forks can trigger it manually.
2. `CITATION.cff` — removed `given-names: ""`, `orcid: ""`, `affiliation: ""`. CFF 1.2.0 requires `orcid`, when present, to match `https://orcid.org/…`, so an empty string fails validation; the other two empty fields add nothing. `family-names` alone is a valid author entry.

**Verified by:** `verify_suite.py` clean ("one entry, one premise, nine modules, no version talk") and controller regression tests 5/5, run locally on macOS with Python 3.x; both edited files additionally parsed with a second YAML implementation (Ruby psych) as a syntax cross-check. A green three-OS matrix run from my fork will be linked in a follow-up comment.

**Not covered:** anything beyond what the two shipped tools themselves check.
