### PR TITLE
Fix controller: read checkpoint coverage and outgoing text beyond English ASCII

### DIFF
--- a/j-space/scripts/jspace.py
+++ b/j-space/scripts/jspace.py
@@ -26,6 +26,13 @@ is write a malformed entry into the ledger, because a ledger you cannot trust is
 worse than no ledger — it looks like state.
 
 Standard library only. No network. Writes exactly one directory: .jspace/
+
+Checkpoint coverage and outgoing claims are recognised in English and Chinese.
+Any other language extends the vocabulary through the environment, as literal
+comma-separated terms:
+
+    JSPACE_COVERAGE_TERMS="toutes,chaque,cas limites,couverture"
+    JSPACE_CLAIM_TERMS="vérifié,confirmé"
 """
 
 import argparse
@@ -75,15 +82,53 @@ class LedgerReadError(Exception):
 # stripping them from good writing costs more than the leak they would catch.
 INNER_ONLY = ["⇒", "⟹", "⟸", "∴", "∵", "⊆", "⊇", "∋", "??", "?!", "💀"]
 MARKERS = ["GRRR", "GAAAH", "PHEW", "I see meltdown", "DATA DATA", "I'M DROWNING"]
-CLAIM = re.compile(r"\b(verified|confirmed|validated|tested|proven)\b", re.I)
-COVERAGE = re.compile(
-    r"(?:\b(?:all|each|every|cases?|inputs?|samples?|bounds?|boundaries|edges?|"
+
+# Claim and coverage vocabularies.
+#
+# The checkpoint gate is deliberate: a checkpoint with no stated coverage is not
+# recorded. That only holds as a gate while the vocabulary can read the language
+# the coverage was written in. Where it cannot, the gate stops separating "no
+# coverage stated" from "coverage stated in a language the pattern cannot read",
+# and refuses a well-formed checkpoint — which is the one thing the controller
+# is not supposed to do.
+#
+# English and Chinese are carried here because the suite is published in both.
+# Any other language extends the vocabulary through the environment rather than
+# by patching this file; see EXTRA_TERMS below.
+CLAIM_EN = r"\b(?:verified|confirmed|validated|tested|proven)\b"
+COVERAGE_EN = (
+    r"\b(?:all|each|every|cases?|inputs?|samples?|bounds?|boundaries|edges?|"
     r"random(?:ized)?|files?|modules?|sections?|lines?|scenarios?|environments?|"
     r"platforms?|datasets?|records?|routes?|commands?|branches?|ranges?|including|"
     r"through|up\s+to|Windows|Linux|macOS|Chrome|Firefox|Safari)\b|"
-    r"\b(?:Python|Node(?:\.js)?)\s*\d|\bn\s*[<≤=]\s*\d)",
-    re.I,
+    r"\b(?:Python|Node(?:\.js)?)\s*\d|\bn\s*[<≤=]\s*\d"
 )
+# Chinese is written without word separators, so \b never fires between a Han
+# character and its neighbour. These alternatives are matched unanchored.
+CLAIM_ZH = r"已验证|已确认|已校验|已测试|验证通过|确认无误"
+COVERAGE_ZH = (
+    r"全部|所有|每个|每一|逐个|逐项|覆盖|用例|边界|极端|随机|"
+    r"包括|包含|全量|各个|范围|场景|分支|模块|文件|环境|平台|数据集"
+)
+
+EXTRA_CLAIM_ENV = "JSPACE_CLAIM_TERMS"
+EXTRA_COVERAGE_ENV = "JSPACE_COVERAGE_TERMS"
+
+
+def extra_terms(name):
+    """Literal comma-separated terms from the environment, escaped for regex use."""
+    raw = os.environ.get(name) or ""
+    return [re.escape(term) for term in (part.strip() for part in raw.split(",")) if term]
+
+
+def vocabulary(*groups):
+    """One case-insensitive pattern over every non-empty alternative group."""
+    alternatives = [group for group in groups if group]
+    return re.compile("(?:" + "|".join(alternatives) + ")", re.I)
+
+
+CLAIM = vocabulary(CLAIM_EN, CLAIM_ZH, *extra_terms(EXTRA_CLAIM_ENV))
+COVERAGE = vocabulary(COVERAGE_EN, COVERAGE_ZH, *extra_terms(EXTRA_COVERAGE_ENV))
 
 
 # ------------------------------------------------------------------------- ledger
@@ -568,13 +613,8 @@ def mode_ship(text):
     return 0
 
 
-def read_outgoing(path):
-    """Read outgoing text without silently accepting an unknown or binary encoding."""
-    try:
-        with open(path, "rb") as fh:
-            data = fh.read()
-    except OSError as exc:
-        return None, "%s (%s)" % (path, exc.strerror or "unreadable")
+def decode_outgoing(data, origin):
+    """Decode outgoing bytes without silently accepting an unknown or binary encoding."""
     try:
         if data.startswith(codecs.BOM_UTF8):
             text = data.decode("utf-8-sig")
@@ -587,8 +627,31 @@ def read_outgoing(path):
             if "\x00" in text:
                 raise UnicodeError("NUL bytes suggest an unsupported encoding")
     except UnicodeError as exc:
-        return None, "%s (cannot decode safely: %s)" % (path, exc)
+        return None, "%s (cannot decode safely: %s)" % (origin, exc)
     return text, None
+
+
+def read_outgoing(path):
+    """Read outgoing text from a file, decoded the same way for every source."""
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()
+    except OSError as exc:
+        return None, "%s (%s)" % (path, exc.strerror or "unreadable")
+    return decode_outgoing(data, path)
+
+
+def read_outgoing_stdin():
+    """Read outgoing text from stdin as bytes.
+
+    Reading the text stream instead would decode through the ambient locale, so
+    the same UTF-8 input inspected as a file and piped through `-` would not
+    produce the same findings.
+    """
+    stream = getattr(sys.stdin, "buffer", None)
+    if stream is None:
+        return sys.stdin.read(), None
+    return decode_outgoing(stream.read(), "stdin")
 
 
 def configure_streams():
@@ -632,8 +695,9 @@ def main(argv=None):
 
     if args.cmd == "ship":
         if args.file == "-":
-            return mode_ship(sys.stdin.read())
-        text, problem = read_outgoing(args.file)
+            text, problem = read_outgoing_stdin()
+        else:
+            text, problem = read_outgoing(args.file)
         if problem:
             print("CANNOT: " + problem + ".")
             print("  pass a readable file, or - to read stdin")

--- a/tests/test_jspace.py
+++ b/tests/test_jspace.py
@@ -29,7 +29,11 @@ class JSpaceControllerTests(unittest.TestCase):
     def history(self):
         return Path(self.workspace.name) / ".jspace" / "history.json"
 
-    def run_controller(self, *args, stdin=None):
+    def run_controller(self, *args, stdin=None, env=None):
+        environment = None
+        if env:
+            environment = dict(os.environ)
+            environment.update(env)
         return subprocess.run(
             [sys.executable, str(CONTROLLER), *args],
             cwd=self.workspace.name,
@@ -38,6 +42,7 @@ class JSpaceControllerTests(unittest.TestCase):
             encoding="utf-8",
             capture_output=True,
             check=False,
+            env=environment,
         )
 
     def open_ledger(self, goal="Ship verified output", next_action="Inspect inputs"):
@@ -167,6 +172,62 @@ class JSpaceControllerTests(unittest.TestCase):
         declined = self.run_controller("ship", os.fspath(outgoing))
         self.assertEqual(declined.returncode, 2)
         self.assertIn("cannot decode safely", declined.stdout)
+
+    def test_checkpoint_coverage_is_read_in_chinese(self):
+        self.open_ledger()
+        recorded = self.run_controller(
+            "note",
+            "--check",
+            "解析器保持状态",
+            "--by",
+            "单元测试，覆盖全部账本区段与边界输入",
+        )
+        self.assertEqual(recorded.returncode, 0, recorded.stdout + recorded.stderr)
+        self.assertIn("✓01", self.ledger.read_text(encoding="utf-8"))
+
+    def test_coverage_vocabulary_extends_through_the_environment(self):
+        self.open_ledger()
+        french = (
+            "note",
+            "--check",
+            "le parseur conserve son état",
+            "--by",
+            "relecture manuelle de toutes les entrées",
+        )
+
+        refused = self.run_controller(*french)
+        self.assertEqual(refused.returncode, 2)
+        self.assertIn("stated coverage", refused.stdout)
+
+        accepted = self.run_controller(
+            *french, env={"JSPACE_COVERAGE_TERMS": "toutes,chaque,cas limites"}
+        )
+        self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+        self.assertIn("✓01", self.ledger.read_text(encoding="utf-8"))
+
+    def test_uncovered_claim_is_reported_in_chinese(self):
+        flagged = self.run_controller("ship", "-", stdin="结果已验证，可以交付。")
+        self.assertEqual(flagged.returncode, 0, flagged.stdout + flagged.stderr)
+        self.assertIn("no stated coverage", flagged.stdout)
+
+        clean = self.run_controller(
+            "ship", "-", stdin="结果已验证：全部用例与边界输入均已覆盖。"
+        )
+        self.assertEqual(clean.returncode, 0, clean.stdout + clean.stderr)
+        self.assertIn("clean", clean.stdout)
+
+    def test_stdin_and_file_inspection_agree_on_the_same_bytes(self):
+        outgoing = Path(self.workspace.name) / "outgoing.md"
+        text = "Résultat A ⇒ B ∴ terminé."
+        outgoing.write_text(text, encoding="utf-8")
+
+        from_file = self.run_controller("ship", os.fspath(outgoing))
+        from_stdin = self.run_controller("ship", "-", stdin=text)
+
+        self.assertEqual(from_file.returncode, 0, from_file.stdout + from_file.stderr)
+        self.assertEqual(from_stdin.returncode, 0, from_stdin.stdout + from_stdin.stderr)
+        self.assertIn("inner-register notation", from_file.stdout)
+        self.assertEqual(from_stdin.stdout, from_file.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The problem

Two defects in `jspace.py`, same root: the controller assumes its input is English ASCII.

### 1. A checkpoint cannot be recorded outside English — `note --check` (blocking)

`--by` must match `COVERAGE`, whose vocabulary is English-only. The suite is published in English and Chinese, but a Chinese `--by` is refused:

```
$ jspace.py note --check "解析器保持状态" --by "单元测试，覆盖全部账本区段与边界输入"
NOT RECORDED: verified without stated coverage is a mood, not a result.
$ echo $?
2
```

Coverage *is* stated there — the pattern cannot read it. So the gate stops separating "no coverage stated" from "coverage stated in a language the pattern cannot read", and refuses a well-formed checkpoint. For a non-English user this makes the documented `loop` lifecycle unreachable: `--check` is the only way into `Verified`.

The gate itself is right, and this PR keeps it. Only its reach is wrong.

### 2. `ship -` inspects mangled text on a non-UTF-8 console (silent)

The file branch decodes bytes explicitly and is BOM-aware; the stdin branch calls `sys.stdin.read()`, which decodes through the ambient locale. `configure_streams()` reconfigures `stdout` and `stderr` but not `stdin`. On a cp1252 Windows console the same bytes give different answers:

```
> "Résultat A ⇒ B ∴ terminé." | python jspace.py ship -
clean — the outgoing register holds.        # ⇒ and ∴ are in INNER_ONLY
```

The register audit reports clean on text it never actually read. That is worse than the first defect, because nothing signals it.

## The fix

- Split `CLAIM` / `COVERAGE` into named per-language groups and add Chinese terms. Chinese is matched without `\b`, which never fires between Han characters.
- Add `JSPACE_COVERAGE_TERMS` and `JSPACE_CLAIM_TERMS`: literal comma-separated terms, `re.escape`d, so a French or Japanese user extends the vocabulary without patching the file. Hard-coding every language does not converge; this does.
- Extract `decode_outgoing()` from `read_outgoing()` and read stdin through `sys.stdin.buffer`, so `ship FILE` and `ship -` follow one decode path — including the BOM handling and the binary refusal.

English behaviour is byte-for-byte unchanged: every existing English term is preserved verbatim, and an uncovered English `--by` is still refused with exit 2.

## Verification

- `python -m unittest discover -s tests` — **9 tests, OK** (5 existing, unmodified, still passing).
- `python j-space/scripts/verify_suite.py` — **clean**; no markdown touched, the premise and backbone checks are untouched.
- Coverage of the 4 new tests: Chinese checkpoint accepted; French refused by default *and* accepted once `JSPACE_COVERAGE_TERMS` is set; Chinese claim without coverage flagged by `ship`; stdin and file inspection asserted byte-identical on the same UTF-8 input.
- Manual regression on Windows PowerShell (cp1252 console), Python 3.13: uncovered English `--by` still exit 2, covered English `--by` still exit 0.

Standard library only, no new dependency, no new file, and the controller still writes exactly `.jspace/`.

## Notes for the maintainer

- The environment override is the part I would most expect you to push back on. If you would rather keep the vocabulary closed, dropping the two `extra_terms(...)` calls leaves the Chinese support and the stdin fix intact and self-contained.
- I did not add `tests?` to `COVERAGE`. "tests" alone is not a coverage statement, and the failure I hit was about language, not about that word.
- Chinese term selection errs toward common scope words (`全部`, `覆盖`, `边界`, `用例`). As with English `including`, a broad term can let a thin claim through `ship`; that tradeoff already exists in the English list and I matched it rather than tightening one language against the other.