### PR TITLE
fix: skip markdown headings in ship check and accept Chinese coverage terms

### DIFF
--- a/j-space/scripts/jspace.py
+++ b/j-space/scripts/jspace.py
@@ -81,7 +81,13 @@ COVERAGE = re.compile(
     r"random(?:ized)?|files?|modules?|sections?|lines?|scenarios?|environments?|"
     r"platforms?|datasets?|records?|routes?|commands?|branches?|ranges?|including|"
     r"through|up\s+to|Windows|Linux|macOS|Chrome|Firefox|Safari)\b|"
-    r"\b(?:Python|Node(?:\.js)?)\s*\d|\bn\s*[<≤=]\s*\d)",
+    r"\b(?:Python|Node(?:\.js)?)\s*\d|\bn\s*[<≤=]\s*\d|"
+    # CJK coverage terms. Chinese has no inter-word spaces, so these match as
+    # substrings without \b. Multi-character terms only: bare single characters
+    # like 行/各/含 would false-match ordinary prose (行动/各自/含义).
+    r"(?:覆盖|全部|所有|每个|每条|各条|每项|用例|输入|样本|样例|边界|上下限|上限|下限|"
+    r"文件|目录|模块|章节|分段|行数|行号|场景|环境|平台|数据集|记录|路由|命令|分支|"
+    r"范围|包括|包含|浏览器|至多|至少|最多|最少|逐一|逐条))",
     re.I,
 )
 
@@ -543,6 +549,8 @@ def mode_ship(text):
         findings.append("state markers in outgoing text: " + ", ".join(hot))
 
     for n, line in enumerate(lines, 1):
+        if line.lstrip().startswith("#"):
+            continue  # headings are structure, not coverage-less claims
         if CLAIM.search(line) and not COVERAGE.search(line):
             findings.append('line %d: "verified" with no stated coverage' % n)
             break

--- a/tests/test_jspace.py
+++ b/tests/test_jspace.py
@@ -145,6 +145,39 @@ class JSpaceControllerTests(unittest.TestCase):
         self.assertIn("ledger was unreadable", result.stdout)
         self.assertNotIn("Traceback", result.stderr)
 
+    def test_ship_skips_section_headings_but_flags_claims(self):
+        heading = self.run_controller("ship", "-", stdin="## Verified\n")
+        self.assertEqual(heading.returncode, 0, heading.stdout + heading.stderr)
+        self.assertIn("clean", heading.stdout)
+
+        claimed = self.run_controller(
+            "ship", "-", stdin="## Verified\nResult verified by intuition\n"
+        )
+        self.assertEqual(claimed.returncode, 0, claimed.stdout + claimed.stderr)
+        self.assertIn('"verified" with no stated coverage', claimed.stdout)
+
+    def test_chinese_coverage_is_accepted(self):
+        self.open_ledger()
+        accepted = self.run_controller(
+            "note",
+            "--check",
+            "结构核对完成",
+            "--by",
+            "直接取证, 覆盖: 所有文件与目录",
+        )
+        self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+        self.assertIn("✓01", accepted.stdout)
+
+        refused = self.run_controller(
+            "note",
+            "--check",
+            "结构核对完成",
+            "--by",
+            "grep 输出",
+        )
+        self.assertEqual(refused.returncode, 2)
+        self.assertIn("without stated coverage", refused.stdout)
+
     def test_history_recovery_and_register_inspection(self):
         self.open_ledger()
         self.history.write_text("{}", encoding="utf-8")


### PR DESCRIPTION
## 问题

两个 coverage 启发式检查的缺陷:

**1. `ship` 对 `## Verified` 标题的误报**

账本里每个章节都有 `## Verified` / `## Goal` 这样的标题行。`ship` 用 `CLAIM` 正则扫描整行,标题里的单词 "Verified" 命中 `CLAIM`,而标题没有覆盖范围词,于是被误报为:

```
· line 8: "verified" with no stated coverage
```

章节标题是结构,不是声明。复现:

```bash
printf '## Verified\n' | python3 j-space/scripts/jspace.py ship -
```

**2. `COVERAGE` 词表不支持中文**

`--by` 的覆盖范围校验用 `COVERAGE` 正则,只列了英文词(all/each/files/…)。中文覆盖声明即使写明了覆盖范围也会被拒写:

```bash
python3 j-space/scripts/jspace.py note --check "结构核对完成" --by "直接取证, 覆盖: 所有文件与目录"
# NOT RECORDED: verified without stated coverage is a mood, not a result.
```

## 修复

1. `ship`:扫描前跳过以 `#` 开头的行(首个非空白字符是 `#`)。标题不再误报;非标题行上真正缺覆盖范围的声明仍会被标记。
2. `COVERAGE`:新增多字符中文覆盖词(覆盖/全部/所有/每个/每条/各条/每项/用例/输入/样本/样例/边界/上下限/上限/下限/文件/目录/模块/章节/分段/行数/行号/场景/环境/平台/数据集/记录/路由/命令/分支/范围/包括/包含/浏览器/至多/至少/最多/最少/逐一/逐条)。中文无词间空格,所以这些词按子串匹配、不加 `\b`;只用 ≥2 字词,避免单字(行/各/含)在普通行文里误命中(行动/各自/含义)。

英文词表行为不变;两个 bug 各补一条回归测试。

## 测试

```bash
python3 -m unittest discover -s tests -v
# Ran 7 tests ... OK   (5 个原有 + 2 个新增)
```

修复后的行为:

```bash
printf '## Verified\n' | python3 j-space/scripts/jspace.py ship -      # clean
printf '## Verified\nResult verified by intuition\n' | python3 j-space/scripts/jspace.py ship -  # 仍标记 line 2
python3 j-space/scripts/jspace.py note --check x --by "覆盖: 所有文件"  # 接受 ✓01
python3 j-space/scripts/jspace.py note --check x --by "grep 输出"       # 仍拒写
```