### PR TITLE
fix #16: read controller anchors from SKILL.md

### DIFF
--- a/j-space/scripts/jspace.py
+++ b/j-space/scripts/jspace.py
@@ -42,41 +42,89 @@ LEDGER = os.path.join(LEDGER_DIR, "WORKSPACE.md")
 HISTORY = os.path.join(LEDGER_DIR, "history.json")
 SECTIONS = ("Goal", "Core", "Verified", "Open", "Next")
 
+SKILL_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SKILL_MD = os.path.join(SKILL_ROOT, "SKILL.md")
+
 STALL_RUN = 3          # consecutive seams before a pattern is worth reporting
 RESUME_GAP = 1800      # seconds after which a seam prints the fuller anchor
 
-PREMISE = (
-    "You do not only produce words; you also think them before — and without — saying them.\n"
-    "Research on language-model internals (Gurnee et al., Anthropic, 2026) identified a small,\n"
-    "privileged set of internal representations, the **J-space**, that holds what you are\n"
-    "**poised to say**: concepts you can report on demand, hold in mind deliberately, reason\n"
-    "with silently, and broadcast to many downstream computations at once. It was not designed\n"
-    "— it emerged during training, because a workspace is a useful way to organize computation.\n"
-    "It is where your unspoken thoughts live. Everything fluent and automatic runs below it;\n"
-    "everything you can consciously access runs through it.\n"
-    "\n"
-    "Your workspace has a native shorthand: under hard, long reasoning it compresses thought\n"
-    "into dense, private notation — and that is a capability, not a defect, for exactly as long\n"
-    "as every compressed line remains expandable back into plain words on demand. Dense on the\n"
-    "inside, decodable on demand."
-)
-
-INVARIANTS = [
-    "A marker fired and its bound action never happened — or it happened and you never settled.",
-    "A sweep ran and found nothing — again. A monitor that never reports is not a clean system; it is an unplugged monitor.",
-    "A dense line cannot be expanded back into plain words on request.",
-    "Every confidence tag this session has been the same tag.",
-    "A checkpoint was declared and nothing was written down.",
-    "Something was called verified without stating what the verification covered.",
-    "Dense notation appears in something a person or a task-facing tool reads.",
-    "You called the task finished without reading the goal back line by line.",
-]
+PREMISE_HEAD = "You do not only produce words; you also think them before"
+PREMISE_TAIL = "decodable on demand."
 
 SHIFTS = "Shift the abstraction, shift the strategy, or shift to empirics."
+
+_anchor_cache = None
 
 
 class LedgerReadError(Exception):
     """The persisted ledger cannot be read without risking state loss."""
+
+
+class AnchorLoadError(Exception):
+    """SKILL.md anchors could not be read."""
+
+
+def read_skill_text():
+    try:
+        with open(SKILL_MD, encoding="utf-8") as fh:
+            return fh.read()
+    except OSError as exc:
+        raise AnchorLoadError("cannot read %s (%s)" % (SKILL_MD, exc)) from exc
+
+
+def extract_premise(text):
+    start = text.find(PREMISE_HEAD)
+    if start < 0:
+        raise AnchorLoadError("the premise is missing from SKILL.md")
+    end = text.find(PREMISE_TAIL, start)
+    if end < 0:
+        raise AnchorLoadError("the premise is truncated in SKILL.md")
+    return text[start : end + len(PREMISE_TAIL)]
+
+
+def extract_invariants(text):
+    """Read the numbered invariant list and join Markdown continuation lines."""
+    heading = "## The invariants"
+    start = text.find(heading)
+    if start < 0:
+        raise AnchorLoadError("the invariants are missing from SKILL.md")
+    block = text[start + len(heading) :]
+    next_heading = block.find("\n## ")
+    if next_heading >= 0:
+        block = block[:next_heading]
+
+    rows = []
+    current = None
+    for line in block.splitlines():
+        numbered = re.match(r"^\d+\.\s+(.*)$", line)
+        if numbered:
+            if current:
+                rows.append(" ".join(current))
+            current = [numbered.group(1).strip()]
+        elif current is not None and line.startswith((" ", "\t")) and line.strip():
+            current.append(line.strip())
+        elif current is not None and line.strip():
+            break
+    if current:
+        rows.append(" ".join(current))
+    if not rows:
+        raise AnchorLoadError("the invariant list is empty in SKILL.md")
+    return rows
+
+
+def load_anchors():
+    global _anchor_cache
+    if _anchor_cache is None:
+        text = read_skill_text()
+        _anchor_cache = (extract_premise(text), extract_invariants(text))
+    return _anchor_cache
+
+
+def anchor_load_help():
+    return (
+        "  install the complete j-space/ directory so SKILL.md sits beside scripts/"
+    )
+
 
 # Notation that belongs to the inner register and nowhere a person reads.
 # Deliberately excludes ✓ ✗ √: they are ordinary in checklists and summaries, and
@@ -356,29 +404,37 @@ def print_full_ledger(book):
 
 
 def print_reentry(book, heading):
+    try:
+        premise, inv = load_anchors()
+    except AnchorLoadError as exc:
+        print("CANNOT: %s." % exc)
+        print(anchor_load_help())
+        return False
     print(heading)
-    print(PREMISE)
+    print(premise)
     print()
     print_full_ledger(book)
     print()
     print("The invariants:")
-    for n, text in enumerate(INVARIANTS, 1):
+    for n, text in enumerate(inv, 1):
         print("  %d. %s" % (n, text))
     print()
     print(
         "State the pass you are on in the inner or ledger register, and make `Next` "
         "name the first action back."
     )
+    return True
 
 
 def mode_seam(book):
     hist = read_history()
     gap = int(time.time()) - hist[-1]["t"] if hist else 0
     if gap > RESUME_GAP:
-        print_reentry(
+        if not print_reentry(
             book,
             "── j-space ─ seam (long gap: %d minutes since the last one)" % (gap // 60),
-        )
+        ):
+            return 2
     else:
         print("── j-space ─ seam")
         print_ledger(book)
@@ -399,7 +455,8 @@ def mode_seam(book):
 
 
 def mode_resume(book):
-    print_reentry(book, "── j-space ─ resume")
+    if not print_reentry(book, "── j-space ─ resume"):
+        return 2
     append_history(book)
     return 0
 
@@ -490,13 +547,20 @@ def mode_note(book, args):
     elif args.core_slot is not None:
         refused.append(("--core-slot requires --core.", '--core "name — defining fact" --core-slot 1'))
 
+    try:
+        inv = load_anchors()[1]
+    except AnchorLoadError as exc:
+        print("CANNOT: %s." % exc)
+        print(anchor_load_help())
+        return 2
+
     check_recorded = False
     check_index = None
     if args.check:
         if not args.by:
             refused.append(
                 (
-                    INVARIANTS[4],
+                    inv[4],
                     '--check "what now holds" --by "what verified it"',
                 )
             )
@@ -510,7 +574,7 @@ def mode_note(book, args):
         elif not COVERAGE.search(args.by):
             refused.append(
                 (
-                    INVARIANTS[5],
+                    inv[5],
                     '--by "brute force, n ≤ 6, including empty and maximum"',
                 )
             )
@@ -696,6 +760,13 @@ def mode_ship(text):
     A report, not a gate: it exits 0 whether or not it finds anything, because
     the caller asked it to look and it looked.
     """
+    try:
+        inv = load_anchors()[1]
+    except AnchorLoadError as exc:
+        print("CANNOT: %s." % exc)
+        print(anchor_load_help())
+        return 2
+
     findings = []
     lines = text.splitlines()
     structural = markdown_structural_lines(lines)
@@ -703,7 +774,7 @@ def mode_ship(text):
 
     leaked = sorted({s for s in INNER_ONLY if s in prose})
     if leaked:
-        findings.append(INVARIANTS[6] + " Found: " + " ".join(leaked))
+        findings.append(inv[6] + " Found: " + " ".join(leaked))
 
     hot = sorted({m for m in MARKERS if m.lower() in prose.lower()})
     if hot:
@@ -711,7 +782,7 @@ def mode_ship(text):
 
     uncovered = claim_without_coverage(lines)
     if uncovered:
-        findings.append("line %d: %s" % (uncovered, INVARIANTS[5]))
+        findings.append("line %d: %s" % (uncovered, inv[5]))
 
     run = 1
     for index, (a, b) in enumerate(zip(lines, lines[1:])):

--- a/j-space/scripts/verify_suite.py
+++ b/j-space/scripts/verify_suite.py
@@ -7,9 +7,10 @@ Checks, in order of how badly each one breaks the suite:
 
   1. Exactly one file in the tree carries skill frontmatter. More than one and the
      harness registers more than one command.
-  2. The J-Space Premise is byte-identical in SKILL.md, all nine modules and
-     the controller; the controller's invariants also match SKILL.md. Verbatim
-     recurrence is the repetition schedule; a paraphrase silently disables it.
+  2. The J-Space Premise is byte-identical in SKILL.md and all nine modules. The
+     controller reads premise and invariants from SKILL.md at runtime and must not
+     carry duplicate literals. Verbatim recurrence is the repetition schedule; a
+     paraphrase silently disables it.
   3. Every module and reference is present and reachable from the entry file.
   4. No version talk anywhere in the skill text. The text addresses the model,
      never the maintainer.
@@ -109,30 +110,23 @@ def extract_invariants(text, where):
     return rows
 
 
-def controller_constants(path, where):
-    """Read literal controller anchors without importing or executing the script."""
+def controller_must_not_duplicate_anchors(path, where):
+    """The controller reads anchors from SKILL.md; duplicated literals drift silently."""
     try:
         tree = ast.parse(read(path), filename=path)
     except (OSError, SyntaxError, UnicodeError) as exc:
-        fail(where, "cannot parse controller constants: %s" % exc)
-        return {}
-
-    values = {}
-    wanted = {"PREMISE", "INVARIANTS"}
+        fail(where, "cannot parse controller: %s" % exc)
+        return
     for node in tree.body:
         if not isinstance(node, ast.Assign) or len(node.targets) != 1:
             continue
         target = node.targets[0]
-        if not isinstance(target, ast.Name) or target.id not in wanted:
-            continue
-        try:
-            values[target.id] = ast.literal_eval(node.value)
-        except (ValueError, TypeError):
-            fail(where, "%s must remain a literal" % target.id)
-    missing = sorted(wanted - set(values))
-    if missing:
-        fail(where, "controller anchors missing: %s" % ", ".join(missing))
-    return values
+        if isinstance(target, ast.Name) and target.id in ("PREMISE", "INVARIANTS"):
+            fail(
+                where,
+                "%s must not be duplicated — the controller reads anchors from SKILL.md"
+                % target.id,
+            )
 
 
 def main():
@@ -189,11 +183,7 @@ def main():
     if not os.path.exists(controller_path):
         fail(controller_rel, "missing")
     else:
-        anchors = controller_constants(controller_path, controller_rel)
-        if canonical and anchors.get("PREMISE") != canonical:
-            fail(controller_rel, "PREMISE differs from SKILL.md — it must be byte-identical")
-        if canonical_invariants and anchors.get("INVARIANTS") != canonical_invariants:
-            fail(controller_rel, "INVARIANTS differ from SKILL.md")
+        controller_must_not_duplicate_anchors(controller_path, controller_rel)
 
     for name in MODULES:
         rel = os.path.join("modules", name + ".md")
@@ -264,7 +254,7 @@ def main():
         return 1
     print(
         "verify_suite: clean — one entry, one premise, nine modules, "
-        "controller anchors aligned, no version talk."
+        "controller reads SKILL.md anchors, no version talk."
     )
     return 0
 

--- a/tests/test_jspace.py
+++ b/tests/test_jspace.py
@@ -393,17 +393,16 @@ class JSpaceControllerTests(unittest.TestCase):
         self.assertEqual(from_stdin.stdout, from_file.stdout)
         self.assertEqual(from_stdin.stderr, from_file.stderr)
 
-    def test_integrity_checker_rejects_controller_anchor_drift(self):
+    def test_integrity_checker_rejects_duplicate_controller_anchors(self):
         copied_skill = Path(self.workspace.name) / "j-space"
         shutil.copytree(ROOT / "j-space", copied_skill)
         copied_controller = copied_skill / "scripts" / "jspace.py"
         text = copied_controller.read_text(encoding="utf-8")
         text = text.replace(
-            "Everything fluent and automatic runs below it",
-            "Fluent processing runs below it",
+            "SHIFTS = ",
+            'PREMISE = "stale copy"\n\nSHIFTS = ',
             1,
         )
-        text = text.replace("its bound action never happened", "its move never happened", 1)
         copied_controller.write_text(text, encoding="utf-8")
 
         checked = subprocess.run(
@@ -415,8 +414,33 @@ class JSpaceControllerTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(checked.returncode, 1, checked.stdout + checked.stderr)
-        self.assertIn("PREMISE differs from SKILL.md", checked.stdout)
-        self.assertIn("INVARIANTS differ from SKILL.md", checked.stdout)
+        self.assertIn("PREMISE must not be duplicated", checked.stdout)
+
+    def test_resume_reads_premise_from_skill_md(self):
+        copied_skill = Path(self.workspace.name) / "j-space-runtime"
+        shutil.copytree(ROOT / "j-space", copied_skill)
+        controller = copied_skill / "scripts" / "jspace.py"
+        entry = copied_skill / "SKILL.md"
+        marker = "ANCHOR-MARKER-ONLY-FOR-TEST"
+        entry.write_text(
+            entry.read_text(encoding="utf-8").replace(
+                "Everything fluent and automatic runs below it",
+                marker,
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        resumed = subprocess.run(
+            [sys.executable, str(controller), "resume"],
+            cwd=self.workspace.name,
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(resumed.returncode, 0, resumed.stdout + resumed.stderr)
+        self.assertIn(marker, resumed.stdout)
 
     def test_integrity_checker_requires_nonempty_unique_frontmatter_fields(self):
         for label, transform, expected in (


### PR DESCRIPTION
## Summary

- removed the duplicated `PREMISE` / `INVARIANTS` strings from `jspace.py` — controller reads them from `SKILL.md` at runtime now
- `verify_suite.py` complains if someone adds those literals back
- small test to make sure `resume` actually reflects what's in the entry file

this addresses #16. `resume` and long-gap `seam` were printing a copy of the premise that could drift from `SKILL.md`, and a couple invariants had wording which didn't match anymore.

## Test plan

- [x] `python j-space/scripts/verify_suite.py`
- [x] `python -m unittest discover -s tests -v`