### PR TITLE
docs: add Codex installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ First inspect the host configuration or documentation to locate the correct Skil
 When finished, report the installed path and verification result, then tell me how this host invokes the Skill. Briefly explain fast, full, and loop, and explain that the optional controller records long-task state rather than choosing solutions. If this host has no native Skill loader, explain the selective system/developer-instruction integration instead of reporting an installation.
 ```
 
+### OpenAI Codex
+
+Codex supports Skills across its CLI, IDE extension, and app. Copy the complete `j-space/`
+directory to one of the [documented Skill locations](https://developers.openai.com/codex/skills):
+
+- `$HOME/.agents/skills/j-space/` for your user account
+- `.agents/skills/j-space/` in a repository for project-only use
+
+Confirm that the resulting path ends in `j-space/SKILL.md`, run
+`scripts/verify_suite.py` with Python 3, and restart Codex if the Skill does not appear.
+Invoke it with `$j-space` or ask Codex to use J-Space for the task. J-Space is
+model-agnostic, so it can be selected with GPT models available in Codex; results still vary
+with the model, harness, and task.
+
 ### Use it
 
 Invoke the Skill through the mechanism provided by your host—such as its Skill picker,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,6 +47,19 @@ J-Space 在推理阶段运行，模型权重和训练过程保持原有状态。
 安装后，请使用可用的 Python 3 解释器运行 scripts/verify_suite.py。完成后告诉我安装路径和校验结果，并说明当前宿主应如何调用这个 Skill。请简要解释 fast、full、loop 三种 pass，以及可选控制器负责记录长任务状态而不负责选择解法。如果当前宿主没有原生 Skill 加载能力，请说明如何通过 system/developer 指令和选择性文件检索完成接入，不要把这种接入报告成原生安装。
 ```
 
+### OpenAI Codex
+
+Codex 的 CLI、IDE 扩展和应用均支持 Skills。请将完整的 `j-space/` 目录复制到
+[官方文档列出的 Skill 位置](https://developers.openai.com/codex/skills)之一：
+
+- `$HOME/.agents/skills/j-space/`：对当前用户的所有项目生效
+- 仓库中的 `.agents/skills/j-space/`：仅对该项目生效
+
+确认最终路径以 `j-space/SKILL.md` 结尾，使用 Python 3 运行
+`scripts/verify_suite.py`；如果 Skill 未显示，请重启 Codex。可通过 `$j-space`
+调用，也可以直接要求 Codex 在任务中使用 J-Space。J-Space 与模型无关，因此可配合
+Codex 中可用的 GPT 模型使用；实际效果仍会随模型、Harness 和任务而变化。
+
 ### 开始使用
 
 通过宿主提供的 Skill 选择器、`/j-space`、`$j-space`，或者直接要求 AI 使用：


### PR DESCRIPTION
## Summary
- document Codex user-level and repository-level Skill locations
- explain verification, restart, and invocation steps in English and Chinese
- clarify that J-Space works with GPT models available through Codex

Closes #3

## Test plan
- [x] Run `python3 j-space/scripts/verify_suite.py`
- [x] Run `python3 -m unittest discover -s tests -v`
- [x] Run `git diff --check`